### PR TITLE
Switch to Global Site Tag, add second tracker

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,13 +19,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="canonical" href="https://dynatrace-apac.github.io//" />
   <link rel="preconnect" href="https://www.google-analytics.com" />
 
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-54510554-1"></script>
   <script>
-    window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-    ga('create', 'UA-49880327-14', 'auto');
-    ga('send', 'pageview');
-    
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'UA-54510554-1');
+    gtag('config', 'UA-49880327-14');	
   </script>
-  <script async src='https://www.google-analytics.com/analytics.js'></script>
 
   <title>Dynatrace Learning Labs | Get Started &amp; Advance with Dynatrace</title>
 


### PR DESCRIPTION
This will send GA data both to 
UA-54510554-1
UA-49880327-14